### PR TITLE
Set foreground text to white when background is magenta

### DIFF
--- a/index.js
+++ b/index.js
@@ -253,7 +253,7 @@ try {
           throw err;
         }
 
-        console.log(Chalk.bgMagenta("Using global hasdep config file in homedir"));
+        console.log(Chalk.bgMagenta(Chalk.white("Using global hasdep config file in homedir")));
         Config = JSON.parse(Fs.readFileSync(configFilePath));
 
         main();
@@ -262,7 +262,7 @@ try {
       return;
     }
 
-    console.log(Chalk.bgMagenta("Using local project hasdep config file"));
+    console.log(Chalk.bgMagenta(Chalk.white("Using local project hasdep config file")));
     Config = JSON.parse(Fs.readFileSync(configFilePath));
 
     main();


### PR DESCRIPTION
At least on my setup (I use [Solarized](http://ethanschoonover.com/solarized)), this is more pleasant to read (new):

<img width="486" alt="screen shot 2016-09-19 at 9 25 03 pm" src="https://cloud.githubusercontent.com/assets/53522/18657500/9048a5fc-7eaf-11e6-9840-9954d4d1f04a.png">

vs. (old):

<img width="482" alt="screen shot 2016-09-19 at 9 23 26 pm" src="https://cloud.githubusercontent.com/assets/53522/18657464/54785482-7eaf-11e6-8c11-f147bb3eb3b3.png">

If this is worse with your setup then let's come up with another combo?
